### PR TITLE
[WIP] Add support for all kwargs in pytds.connect

### DIFF
--- a/sqlserver/base.py
+++ b/sqlserver/base.py
@@ -27,7 +27,15 @@ DatabaseError = pytds.DatabaseError
 IntegrityError = pytds.IntegrityError
 
 
-_SUPPORTED_OPTIONS = ['failover_partner']
+_SUPPORTED_OPTIONS = [
+    'dsn', 'timeout',
+    'login_timeout', 'as_dict',
+    'appname', 'tds_version',
+    'blocksize', 'auth',
+    'readonly', 'bytes_to_unicode',
+    'row_strategy', 'cafile',
+    'validate_host', 'enc_login_only',
+]
 
 
 def utc_tzinfo_factory(offset):


### PR DESCRIPTION
This is the simplest way of fixing #22. At least I don't see a reason, why not support all the `kwargs`, that `pytds.connect` accepts. If it needs some more work I'm open to help.